### PR TITLE
Add CdoConfirm and LdoConfirm options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,28 @@
 Cdo
 ===
-
-Runs the same command over every entry in the quickfix list (:Cdo) or location list (:Ldo).
-
 Example: Find every instance of foo in the working directory and replace it with bar.
 
     :grep foo
     :Cdo s/foo/bar/c | update
 
+Commands
+===
+
+`:Cdo [command]`
+
+&nbsp;&nbsp;&nbsp;&nbsp;Runs the same command over every entry in the quickfix list.
+
+`:Ldo [command]`
+
+&nbsp;&nbsp;&nbsp;&nbsp;Runs the same command over every entry in the location list.
+
+`:Cdo/c [command]`
+
+&nbsp;&nbsp;&nbsp;&nbsp;Just like |:Cdo|, but asks for confirmation before changing each file.
+
+`:Ldo/c [command]`
+
+&nbsp;&nbsp;&nbsp;&nbsp;Just like |:Ldo|, but asks for confirmation before changing each file.
 
 Author
 ------

--- a/plugin/cdo.vim
+++ b/plugin/cdo.vim
@@ -1,24 +1,19 @@
-function! s:Cdo(command)
-  crewind
-  let error_count = len(getqflist())
+function! s:_cdo(args, type)
+  let no_confirmation_needed = matchstr(a:args,'^/c') == ""
+  let command = substitute(a:args, '^/c', '', '')
+
+  exe a:type.'rewind'
+  let error_count = a:type == 'c' ? len(getqflist()) : len(getloclist(0))
   let i = 0
   while i < error_count
     let i = i + 1
-    exe "cc ".i
-    exe a:command
+    exe a:type.a:type." ".i
+    let confirm_msg = "Change this line? - ".getline(".")
+    if no_confirmation_needed || confirm(confirm_msg, "&yes\n&no") == 1
+      exe command
+    endif
   endwhile
 endfunction
 
-function! s:Ldo(command)
-  lrewind
-  let error_count = len(getloclist(0))
-  let i = 0
-  while i < error_count
-    let i = i + 1
-    exe "ll ".i
-    exe a:command
-  endwhile
-endfunction
-
-command! -nargs=1 -bar Cdo :call s:Cdo(<q-args>)
-command! -nargs=1 -bar Ldo :call s:Ldo(<q-args>)
+command! -nargs=1 -bar Cdo :call s:_cdo(<q-args>, 'c')
+command! -nargs=1 -bar Ldo :call s:_cdo(<q-args>, 'l')


### PR DESCRIPTION
This patch adds `:CdoConfirm` and `:LdoConfirm`, which do the same thing as `:Cdo` and `:Ldo`, except that they ask for confirmation before changing each file.

When I'm running the same macro over a long list of files (say, changing a bunch of specs to use newer syntax), there are inevitably some that were formatted differently initially and are messed up by the macro. Having the confirmation option makes it much easier to do bulk edits safely.
